### PR TITLE
fix: repair chores card JSX layout

### DIFF
--- a/frontend/src/components/chores/ChoreCard.tsx
+++ b/frontend/src/components/chores/ChoreCard.tsx
@@ -188,9 +188,6 @@ export function ChoreCard({
             </p>
           </div>
 
-          {triggerLabel && (
-            <span className="solar-chip shrink-0 rounded-full px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]">
-              {triggerLabel}
           <div className="flex flex-col items-end gap-2">
             {triggerLabel && (
               <span className="shrink-0 rounded-full border border-primary/25 bg-primary/10 px-3 py-1 text-[10px] uppercase tracking-[0.18em] text-primary">


### PR DESCRIPTION
## Summary
This PR fixes a JSX structure error in the chores card component that broke the frontend production build and prevented the Docker frontend image from building successfully.

## Problem
A duplicated `triggerLabel` rendering block in `frontend/src/components/chores/ChoreCard.tsx` left an opening `<span>` without a matching closing tag before the right-side action container. That malformed JSX caused TypeScript parsing to fail during the frontend build.

## Root Cause
During recent UI changes, a duplicate `triggerLabel` fragment was left in place immediately before the action column:
- an extra conditional block started rendering a `solar-chip` wrapper
- the block was interrupted by the action container `<div className="flex flex-col items-end gap-2">`
- the resulting markup was syntactically invalid and caused the production build to stop with JSX closing-tag errors

## Fix
This PR keeps the intended right-side layout and removes only the stray duplicated fragment.

### What changed
- removed the malformed duplicate `triggerLabel` block in `frontend/src/components/chores/ChoreCard.tsx`
- preserved the existing, correct trigger badge rendering inside the action column
- left behavior, styling intent, and surrounding component structure unchanged

## Why this approach
This is a minimal root-cause fix:
- it restores valid JSX without refactoring unrelated chores UI
- it avoids altering runtime behavior beyond removing the broken duplicate fragment
- it unblocks frontend builds, Docker image creation, and local app startup

## Validation
The following checks passed after the fix:
- frontend editor diagnostics: no errors in `ChoreCard.tsx`
- `npm run build`
- pre-commit hook suite
- pre-push hook suite
- frontend tests: 41 test files passed, 373 tests passed
- Docker rebuild: `docker compose build --no-cache`
- Docker startup: `docker compose up -d`
- runtime health checks:
  - frontend responded on `http://127.0.0.1:5173`
  - backend health endpoint passed on `http://127.0.0.1:8000/api/v1/health`

## Scope
This PR intentionally does not modify unrelated chores behavior or styling beyond fixing the broken JSX structure.
