### PR TITLE
Add .cgcignore file for CodeGraph context filtering

### DIFF
--- a/.cgcignore
+++ b/.cgcignore
@@ -1,0 +1,26 @@
+# Dependency directories
+node_modules/
+venv/
+.venv/
+__pycache__/
+
+# Build artifacts
+dist/
+build/
+target/
+*.egg-info/
+
+# Tests (Optional - if you only want source code)
+tests/
+spec/
+**/*_test.py
+**/*.test.js
+
+# Sensitive files
+.env
+config.js
+secrets.json
+
+# Documentation
+docs/
+*.md


### PR DESCRIPTION
## Summary

Adds a `.cgcignore` file to configure CodeGraph context filtering.

## Changes

- **`.cgcignore`** — New file that excludes the following from CodeGraph indexing:
  - Dependency directories (`node_modules/`, `venv/`, `.venv/`, `__pycache__/`)
  - Build artifacts (`dist/`, `build/`, `target/`, `*.egg-info/`)
  - Test files (`tests/`, `spec/`, `**/*_test.py`, `**/*.test.js`)
  - Sensitive files (`.env`, `config.js`, `secrets.json`)
  - Documentation (`docs/`, `*.md`)