### PR TITLE
fix: recover stalled pipelines and preserve chore template renames

### DIFF
--- a/backend/src/services/chores/service.py
+++ b/backend/src/services/chores/service.py
@@ -874,6 +874,17 @@ class ChoresService:
 
         needs_pr = "template_content" in updates or "name" in updates
 
+        # When the name changes, derive the new template_path and remember
+        # the old one so the repo commit can delete-and-create atomically.
+        old_template_path: str | None = None
+        if "name" in updates:
+            from src.services.chores.template_builder import derive_template_path
+
+            new_path = derive_template_path(updates["name"])
+            if new_path != chore.template_path:
+                old_template_path = chore.template_path
+                updates["template_path"] = new_path
+
         if expected_sha and needs_pr and github_service and access_token and owner and repo:
             response = await github_service.rest_request(
                 access_token,
@@ -940,6 +951,7 @@ class ChoresService:
                     chore_name=chore.name,
                     template_path=chore.template_path,
                     template_content=build_template(chore.name, chore.template_content),
+                    old_template_path=old_template_path,
                 )
                 pr_number = result.get("pr_number")
                 pr_url = result.get("pr_url")

--- a/backend/src/services/chores/template_builder.py
+++ b/backend/src/services/chores/template_builder.py
@@ -228,8 +228,13 @@ async def update_template_in_repo(
     chore_name: str,
     template_path: str,
     template_content: str,
+    old_template_path: str | None = None,
 ) -> dict:
     """Update an existing chore template in the repo via branch + PR.
+
+    When the chore is renamed, *old_template_path* points to the previous
+    file.  The commit will create the file at *template_path* and delete
+    *old_template_path* in a single atomic commit so the rename is clean.
 
     Args:
         github_service: GitHubProjectsService instance.
@@ -237,8 +242,9 @@ async def update_template_in_repo(
         owner: Repository owner.
         repo: Repository name.
         chore_name: Chore display name.
-        template_path: Existing template file path.
+        template_path: Target template file path (new path when renamed).
         template_content: Updated template content (with front matter).
+        old_template_path: Previous file path to delete when renamed.
 
     Returns:
         Dict with keys: pr_number, pr_url
@@ -264,6 +270,11 @@ async def update_template_in_repo(
         if branch_head:
             commit_base_oid = branch_head
 
+    # When renamed, delete the old file in the same commit.
+    deletions = None
+    if old_template_path and old_template_path != template_path:
+        deletions = [old_template_path]
+
     commit_oid = await github_service.commit_files(
         access_token,
         owner,
@@ -272,6 +283,7 @@ async def update_template_in_repo(
         commit_base_oid,
         [{"path": template_path, "content": template_content}],
         f"chore: update {chore_name}",
+        deletions=deletions,
     )
     if commit_oid is None:
         raise RuntimeError(f"Failed to commit template update to {branch_name}")

--- a/backend/src/services/copilot_polling/recovery.py
+++ b/backend/src/services/copilot_polling/recovery.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import src.services.copilot_polling as _cp
-from src.constants import STALLED_LABEL, find_agent_label, has_stalled_label
+from src.constants import STALLED_LABEL
 from src.logging_utils import get_logger
 from src.models.agent import AgentStepState
 from src.services.github_projects.identities import is_copilot_author
@@ -441,17 +441,15 @@ async def recover_stalled_issues(
             if await _should_skip_recovery(issue_number, task_owner, task_repo, now):
                 continue
 
-            # ── Label-based early exit ────────────────────────────────────
-            # If the task has a valid agent label and is not marked stalled,
-            # the pipeline is demonstrably active — skip the expensive issue
-            # body fetch and tracking table parse.
-            task_labels = getattr(task, "labels", None) or []
-            if find_agent_label(task_labels) and not has_stalled_label(task_labels):
-                logger.debug(
-                    "Recovery: skipping issue #%d — has active agent label, not stalled",
-                    issue_number,
-                )
-                continue
+            # NOTE: A label-based early exit was previously here, skipping
+            # issues with an agent:* label on the assumption that the agent
+            # is actively working.  However, having an agent label only
+            # proves a Copilot assignment was *attempted* — Copilot may
+            # have silently failed to start (no WIP PR).  When that
+            # happens, both the pipeline check (which sees tracking=Active
+            # and waits) and recovery (which skipped due to the label)
+            # would deadlock — permanently stalling the pipeline.
+            # Removed to allow recovery to always verify actual work.
 
             # ── Read the issue body tracking table ────────────────────────
             try:

--- a/backend/tests/unit/test_chores_service.py
+++ b/backend/tests/unit/test_chores_service.py
@@ -305,9 +305,67 @@ class TestInlineUpdateChore:
         assert exc_info.value.current_sha == "current-sha"
         assert exc_info.value.current_content == "Updated content"
 
+    @pytest.mark.anyio
+    async def test_name_change_updates_template_path_and_deletes_old_file(self, mock_db):
+        """Renaming a chore should update template_path in DB and delete the old file in the PR."""
+        from unittest.mock import AsyncMock
 
-# =============================================================================
-# ChoresService.trigger_chore
+        from src.models.chores import ChoreCreate, ChoreInlineUpdate
+        from src.services.chores.service import ChoresService
+
+        service = ChoresService(mock_db)
+        chore = await service.create_chore(
+            "PVT_1",
+            ChoreCreate(name="Old Name", template_content="Body content"),
+            template_path=".github/ISSUE_TEMPLATE/chore-old-name.md",
+        )
+        assert chore.template_path == ".github/ISSUE_TEMPLATE/chore-old-name.md"
+
+        mock_github = AsyncMock()
+        mock_github.get_repository_info.return_value = {
+            "repository_id": "R_1",
+            "default_branch": "main",
+            "head_oid": "abc123",
+        }
+        mock_github.create_branch.return_value = "ref-id"
+        mock_github.commit_files.return_value = "commit-oid"
+        mock_github.create_pull_request.return_value = {
+            "number": 99,
+            "url": "https://github.com/test/repo/pull/99",
+        }
+
+        result = await service.inline_update_chore(
+            chore.id,
+            ChoreInlineUpdate(name="New Name", template_content="Updated body"),
+            github_service=mock_github,
+            access_token="token",
+            owner="test",
+            repo="repo",
+            project_id="PVT_1",
+        )
+
+        # DB should have the new template_path
+        updated = result["chore"]
+        assert updated.name == "New Name"
+        assert updated.template_path == ".github/ISSUE_TEMPLATE/chore-new-name.md"
+
+        # commit_files should have been called with the new path and old path as deletion
+        mock_github.commit_files.assert_awaited_once()
+        commit_call = mock_github.commit_files.call_args
+        files_arg = (
+            commit_call.args[5] if len(commit_call.args) > 5 else commit_call.kwargs.get("files")
+        )
+        # Files may be positional or keyword — check the committed file path
+        assert any(f["path"] == ".github/ISSUE_TEMPLATE/chore-new-name.md" for f in files_arg)
+        # The old file path should be in the deletions kwarg
+        deletions = commit_call.kwargs.get("deletions") or (
+            commit_call.args[8] if len(commit_call.args) > 8 else None
+        )
+        assert deletions == [".github/ISSUE_TEMPLATE/chore-old-name.md"]
+
+        assert result["pr_number"] == 99
+
+
 # =============================================================================
 
 


### PR DESCRIPTION
## Summary

This PR packages two backend fixes that were already validated locally and on push:

1. Recover agent pipelines that get stuck in an `Active` state without any WIP PR being created.
2. Preserve template path changes when a chore is renamed, including deleting the old issue template file in the same repo update flow.

## Problem

### 1. Agent pipelines could deadlock permanently
The recovery flow treated the presence of an `agent:*` label as proof that Copilot was actively working. That assumption is not always true. If Copilot assignment was attempted but no WIP PR was ever created, the system could get stuck in this state:

- tracking table shows `🔄 Active`
- no linked PR exists
- normal pipeline checks wait because the agent is marked active
- recovery skips the issue because an `agent:*` label is present

That created a deadlock where neither the normal poller nor recovery would re-trigger the agent.

### 2. Renaming a chore did not preserve the underlying template file path correctly
When a chore name changed, the stored issue template path needed to move with it. Without explicitly carrying the old path through the repo update flow, the generated repo update would create/update the new file path but would not cleanly remove the old one in the same atomic change.

## Changes

### Pipeline recovery
- Removed the label-based early exit from `recover_stalled_issues()`.
- Recovery now always validates actual GitHub state instead of assuming an active label means work is progressing.
- This allows stalled issues to be re-assigned when there is no WIP PR, even if the tracking table still says `Active`.
- Removed the now-unused imports tied to the old fast-path.

### Chore template rename handling
- In `ChoresService.inline_update_chore()`, when `name` changes:
  - derive the new `template_path`
  - capture the previous template path
  - persist the new path in the chore update
- In `update_template_in_repo()`:
  - accept `old_template_path`
  - compute a `deletions` list when the path changed
  - pass that deletion list into `commit_files()` so the rename is represented as a create/update + delete in one repo commit

### Test coverage
- Added coverage for chore rename behavior to ensure:
  - the chore record stores the new template path
  - the repo update writes the renamed template path
  - the old template path is deleted in the same commit payload

## Validation

Local targeted verification:
- `python -m pytest tests/unit/test_copilot_polling.py tests/unit/test_chores_service.py -x -q`
- Result: `302 passed`

Push-time validation:
- Backend suite ran automatically before push
- Result: `1983 passed, 2 deselected`
- Frontend tests were also kicked off by the push hook

## Runtime confirmation

The pipeline recovery fix was also verified against issue `#3868` in runtime logs. After the cooldown expired, recovery detected the stall condition (`no WIP PR found`) and re-assigned `speckit.specify` successfully instead of skipping the issue due to the active agent label.

## Files changed

- `backend/src/services/copilot_polling/recovery.py`
- `backend/src/services/chores/service.py`
- `backend/src/services/chores/template_builder.py`
- `backend/tests/unit/test_chores_service.py`

## Notes

The push-time backend test run emitted pre-existing runtime warnings in workflow orchestrator transition tests. Those warnings were not introduced by this PR and were not changed here.