### PR TITLE
fix: start newly-entered parallel pipeline groups immediately

### DIFF
--- a/backend/src/services/copilot_polling/pipeline.py
+++ b/backend/src/services/copilot_polling/pipeline.py
@@ -1484,9 +1484,15 @@ async def _advance_pipeline(
     if pipeline.groups and pipeline.current_group_index < len(pipeline.groups):
         group = pipeline.groups[pipeline.current_group_index]
         if group.execution_mode == "parallel" and group.agents:
-            # Treat missing agent_statuses entries as non-terminal
-            still_active = len(group.agent_statuses) < len(group.agents) or any(
-                s not in ("completed", "failed") for s in group.agent_statuses.values()
+            # Only wait when a parallel group has already started. A freshly
+            # entered group has all agents pending and must be assigned now.
+            has_started = any(
+                status in ("active", "completed", "failed")
+                for status in group.agent_statuses.values()
+            )
+            still_active = has_started and (
+                len(group.agent_statuses) < len(group.agents)
+                or any(s not in ("completed", "failed") for s in group.agent_statuses.values())
             )
             if still_active:
                 # Other parallel agents are still running — do NOT assign a new agent

--- a/backend/tests/unit/test_copilot_polling.py
+++ b/backend/tests/unit/test_copilot_polling.py
@@ -2742,6 +2742,105 @@ class TestAdvancePipeline:
         # successful merge to keep rollback consistent.
         mock_update_tracking.assert_not_called()
 
+    @pytest.mark.asyncio
+    @patch("src.services.copilot_polling.pipeline.asyncio.sleep", new_callable=AsyncMock)
+    @patch("src.services.copilot_polling._update_issue_tracking", new_callable=AsyncMock)
+    @patch("src.services.copilot_polling.github_projects_service")
+    @patch("src.services.copilot_polling.connection_manager")
+    @patch("src.services.copilot_polling.get_issue_main_branch")
+    @patch("src.services.copilot_polling._merge_child_pr_if_applicable")
+    @patch("src.services.copilot_polling.get_workflow_orchestrator")
+    @patch("src.services.copilot_polling.get_workflow_config", new_callable=AsyncMock)
+    @patch("src.services.copilot_polling.set_pipeline_state")
+    async def test_assigns_new_parallel_group_after_sequential_completion(
+        self,
+        mock_set_state,
+        mock_config,
+        mock_get_orchestrator,
+        mock_merge,
+        mock_get_branch,
+        mock_ws,
+        mock_service,
+        mock_update_tracking,
+        mock_sleep,
+    ):
+        """A newly-entered parallel group must be assigned immediately.
+
+        Regression for issue #3890: after a sequential group completed, the
+        next parallel group was treated as already active because its status
+        map was incomplete, so _advance_pipeline returned `parallel_wait`
+        before assigning any of the pending agents.
+        """
+        from src.services.workflow_orchestrator.models import PipelineGroupInfo
+
+        pipeline = PipelineState(
+            issue_number=42,
+            project_id="PVT_123",
+            status="In Progress",
+            agents=["speckit.implement", "linter", "archivist", "judge"],
+            current_agent_index=0,
+            completed_agents=[],
+            groups=[
+                PipelineGroupInfo(
+                    group_id="g1",
+                    execution_mode="sequential",
+                    agents=["speckit.implement"],
+                ),
+                PipelineGroupInfo(
+                    group_id="g2",
+                    execution_mode="parallel",
+                    agents=["linter", "archivist", "judge"],
+                    agent_statuses={
+                        "linter": "pending",
+                        "archivist": "pending",
+                        "judge": "pending",
+                    },
+                ),
+            ],
+            current_group_index=0,
+            current_agent_index_in_group=0,
+        )
+
+        mock_get_branch.return_value = None
+        mock_merge.return_value = None
+        mock_ws.broadcast_to_project = AsyncMock()
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.assign_agent_for_status = AsyncMock(return_value=True)
+        mock_get_orchestrator.return_value = mock_orchestrator
+        mock_config.return_value = MagicMock()
+        mock_update_tracking.return_value = True
+
+        result = await _advance_pipeline(
+            access_token="token",
+            project_id="PVT_123",
+            item_id="PVTI_123",
+            owner="owner",
+            repo="repo",
+            issue_number=42,
+            issue_node_id="I_123",
+            pipeline=pipeline,
+            from_status="In Progress",
+            to_status="In Review",
+            task_title="Test Issue",
+        )
+
+        assert result["status"] == "success"
+        assert result["action"] == "parallel_group_assigned"
+        assert result["agent_name"] == "linter, archivist, judge"
+        assert pipeline.current_group_index == 1
+        assert pipeline.groups[1].agent_statuses == {
+            "linter": "active",
+            "archivist": "active",
+            "judge": "active",
+        }
+
+        assert mock_orchestrator.assign_agent_for_status.await_count == 3
+        called_indices = [
+            call.kwargs["agent_index"]
+            for call in mock_orchestrator.assign_agent_for_status.await_args_list
+        ]
+        assert called_indices == [1, 2, 3]
+
 
 class TestFindCompletedChildPr:
     """Tests for _find_completed_child_pr function."""


### PR DESCRIPTION
## Summary

This PR fixes a pipeline orchestration bug where a newly-entered parallel execution group could be treated as already running before any of its agents had actually been assigned.

The result was that grouped agents configured to run in parallel did not fan out together. Instead, the system returned early, left those agents in a pending state, and recovery later backfilled them one at a time.

This behavior was reproduced on parent issue `#3890`.

## Root Cause

The bug was in `_advance_pipeline()` in `backend/src/services/copilot_polling/pipeline.py`.

After a sequential group completed, the code advanced `current_group_index` to the next group. If that next group was parallel, the guard intended to detect "parallel group still running" evaluated true too early:

- it treated an incomplete `agent_statuses` map as proof that the group was active
- but for a freshly-entered parallel group, that map is incomplete specifically because no agents have been assigned yet
- `_advance_pipeline()` then returned `parallel_wait` before reaching the batch assignment path

That prevented the normal fan-out for the new parallel group.

In runtime, the consequence was:

- no `parallel_group_assigned` path executed for the fresh group
- agents remained pending in the tracking table
- recovery eventually detected each missing assignment and re-assigned agents individually
- the parallel stage effectively serialized over time instead of launching as a batch

## Changes

### Pipeline advancement fix
In `backend/src/services/copilot_polling/pipeline.py`:

- refined the early wait guard for parallel groups
- a parallel group now waits only if it has already started
- a freshly-entered parallel group with only pending members now falls through to the batch assignment block as intended

### Regression coverage
In `backend/tests/unit/test_copilot_polling.py`:

- added a regression test for the exact failing transition
- the test models:
  - one completed sequential group
  - the next group marked as `parallel`
  - all next-group members still `pending`
- it verifies that `_advance_pipeline()`:
  - returns `parallel_group_assigned`
  - assigns every agent in the new parallel group immediately
  - uses the expected flattened agent indices for assignment

## Why This Fix Is Correct

The system needs to distinguish between two very different states:

1. A parallel group that has already started and still has active work.
2. A parallel group that has just been entered and has not started yet.

Before this change, both states collapsed into the same branch because incomplete status bookkeeping was treated as equivalent to active work.

After this change:

- "already started" groups still wait correctly
- "not yet started" groups now assign correctly

That preserves the intended semantics of grouped parallel execution without changing recovery behavior for genuinely active groups.

## Validation

Local verification:

- `python -m pytest tests/unit/test_copilot_polling.py -k "parallel_group or TestAdvancePipeline" -x -q`
- Result: `9 passed`

Full polling test file:

- `python -m pytest tests/unit/test_copilot_polling.py -x -q`
- Result: `268 passed`

Push-time verification:

- backend push hook test suite ran automatically
- Result: `1984 passed, 2 deselected`

## Runtime Impact

This addresses the failure mode observed on issue `#3890`, where agents configured in parallel groups were not launched together and instead had to be recovered individually later.

With this fix, when a sequential group completes and the next group is parallel, the new parallel group should fan out immediately through the normal assignment path.

## Files Changed

- `backend/src/services/copilot_polling/pipeline.py`
- `backend/tests/unit/test_copilot_polling.py`

## Notes

The push-time backend run emitted pre-existing warnings from workflow orchestrator transition tests. Those warnings were not introduced by this change and were not modified in this PR.