### PR TITLE
fix: Parallel execution groups running sequentially instead of in parallel

### DIFF
--- a/solune/backend/src/services/copilot_polling/pipeline.py
+++ b/solune/backend/src/services/copilot_polling/pipeline.py
@@ -502,9 +502,70 @@ async def _process_pipeline_completion(
             task_title=task.title,
         )
 
+    # ── Parallel group: check ALL active agents, not just current_agent ──
+    # For parallel groups, multiple agents run simultaneously. current_agent
+    # always points to agents[0] (current_agent_index_in_group stays at 0
+    # for parallel). We must check every agent with "active" status and
+    # advance for each one that has completed.
+    if pipeline.groups and pipeline.current_group_index < len(pipeline.groups):
+        group = pipeline.groups[pipeline.current_group_index]
+        if group.execution_mode == "parallel" and group.agents:
+            last_result: dict[str, Any] | None = None
+            for agent_name in list(group.agents):
+                # Skip agents that are already completed or failed
+                agent_status = group.agent_statuses.get(agent_name, "pending")
+                if agent_status in ("completed", "failed"):
+                    continue
+                # Skip agents that are still pending (not yet assigned)
+                if agent_status == "pending":
+                    continue
+
+                completed = await _cp._check_agent_done_on_sub_or_parent(
+                    access_token=access_token,
+                    owner=task_owner,
+                    repo=task_repo,
+                    parent_issue_number=task.issue_number,
+                    agent_name=agent_name,
+                    pipeline=pipeline,
+                )
+                if completed:
+                    result = await _advance_pipeline(
+                        access_token=access_token,
+                        project_id=project_id,
+                        item_id=task.github_item_id,
+                        owner=task_owner,
+                        repo=task_repo,
+                        issue_number=task.issue_number,
+                        issue_node_id=task.github_content_id,
+                        pipeline=pipeline,
+                        from_status=from_status,
+                        to_status=to_status,
+                        task_title=task.title,
+                        completed_agent_name=agent_name,
+                    )
+                    if result:
+                        last_result = result
+                    # If pipeline advanced to next group (all done),
+                    # stop checking this group's agents.
+                    if pipeline.is_complete or (
+                        pipeline.current_group_index != pipeline.groups.index(group)
+                        if group in pipeline.groups
+                        else True
+                    ):
+                        break
+            if last_result is not None:
+                return last_result
+            # Fall through to the "never assigned" check below for the
+            # current_agent in case no parallel agent was detected as done.
+
     # Check if current agent has completed
     current_agent = pipeline.current_agent
     if current_agent:
+        # Skip if this agent was already completed (e.g. parallel group,
+        # already handled above, or duplicate detection).
+        if current_agent in pipeline.completed_agents:
+            return None
+
         completed = await _cp._check_agent_done_on_sub_or_parent(
             access_token=access_token,
             owner=task_owner,
@@ -1174,6 +1235,7 @@ async def _advance_pipeline(
     from_status: str,
     to_status: str,
     task_title: str,
+    completed_agent_name: str | None = None,
 ) -> dict[str, Any] | None:
     """
     Advance the pipeline after an agent completes.
@@ -1193,11 +1255,13 @@ async def _advance_pipeline(
         from_status: Current status
         to_status: Target status after pipeline completion
         task_title: Task title for logging
+        completed_agent_name: Explicit agent that completed (for parallel groups
+            where current_agent may not point to the completed agent).
 
     Returns:
         Result dict or None
     """
-    completed_agent = pipeline.current_agent
+    completed_agent = completed_agent_name or pipeline.current_agent
     if completed_agent is None:
         logger.error("No current agent in pipeline — cannot advance")
         return None
@@ -1886,6 +1950,44 @@ async def _transition_after_pipeline_complete(
                     new_status_agents[0],
                 )
 
+        # Build group info for the new status from config.group_mappings.
+        # Without this, the pipeline state created by assign_agent_for_status
+        # would have groups=[] (because remove_pipeline_state cleared the old
+        # state), causing all subsequent parallel execution logic to be bypassed
+        # and parallel groups to run sequentially.
+        new_groups: list[_cp.PipelineGroupInfo] = []
+        if config and getattr(config, "group_mappings", None):
+            status_groups = config.group_mappings.get(effective_status, [])
+            new_groups = [
+                _cp.PipelineGroupInfo(
+                    group_id=gm.group_id,
+                    execution_mode=gm.execution_mode,
+                    agents=[a.slug for a in gm.agents],
+                    agent_statuses=(
+                        {a.slug: "pending" for a in gm.agents}
+                        if gm.execution_mode == "parallel"
+                        else {}
+                    ),
+                )
+                for gm in sorted(status_groups, key=lambda g: g.order)
+            ]
+
+        # Pre-create the pipeline state WITH groups so that
+        # assign_agent_for_status picks up the group info and the polling
+        # loop preserves it across cycles.
+        if new_groups:
+            _cp.set_pipeline_state(
+                issue_number,
+                _cp.PipelineState(
+                    issue_number=issue_number,
+                    project_id=project_id,
+                    status=effective_status,
+                    agents=new_status_agents,
+                    groups=new_groups,
+                    started_at=utcnow(),
+                ),
+            )
+
         orchestrator = _cp.get_workflow_orchestrator()
         ctx = _cp.WorkflowContext(
             session_id="polling",
@@ -1899,13 +2001,52 @@ async def _transition_after_pipeline_complete(
         )
         ctx.config = config
 
-        logger.info(
-            "Assigning agent '%s' to issue #%d after transition to '%s'",
-            new_status_agents[0],
-            issue_number,
-            to_status,
-        )
-        await orchestrator.assign_agent_for_status(ctx, effective_status, agent_index=0)
+        # If the first group is parallel, assign ALL agents in it with a
+        # 2s stagger for rate-limit safety — identical to the parallel
+        # dispatch in _advance_pipeline.
+        if (
+            new_groups
+            and new_groups[0].execution_mode == "parallel"
+            and len(new_groups[0].agents) > 1
+        ):
+            logger.info(
+                "Assigning parallel group '%s' (%d agents) to issue #%d after transition to '%s'",
+                new_groups[0].group_id,
+                len(new_groups[0].agents),
+                issue_number,
+                to_status,
+            )
+            for i, agent_slug in enumerate(new_groups[0].agents):
+                if i > 0:
+                    await asyncio.sleep(2)
+                try:
+                    agent_flat_idx = new_status_agents.index(agent_slug)
+                except ValueError:
+                    agent_flat_idx = i
+                new_groups[0].agent_statuses[agent_slug] = "active"
+                await orchestrator.assign_agent_for_status(
+                    ctx, effective_status, agent_index=agent_flat_idx
+                )
+            _cp.set_pipeline_state(
+                issue_number,
+                _cp.get_pipeline_state(issue_number)
+                or _cp.PipelineState(
+                    issue_number=issue_number,
+                    project_id=project_id,
+                    status=effective_status,
+                    agents=new_status_agents,
+                    groups=new_groups,
+                    started_at=utcnow(),
+                ),
+            )
+        else:
+            logger.info(
+                "Assigning agent '%s' to issue #%d after transition to '%s'",
+                new_status_agents[0],
+                issue_number,
+                to_status,
+            )
+            await orchestrator.assign_agent_for_status(ctx, effective_status, agent_index=0)
 
     return {
         "status": "success",

--- a/solune/backend/src/services/workflow_orchestrator/models.py
+++ b/solune/backend/src/services/workflow_orchestrator/models.py
@@ -200,7 +200,8 @@ class PipelineState:
                 if len(group.agent_statuses) < len(group.agents):
                     return False
                 return all(s in ("completed", "failed") for s in group.agent_statuses.values())
-            return False
+            # Sequential group: complete when index is past all agents
+            return self.current_agent_index_in_group >= len(group.agents)
         # Flat fallback (existing behavior)
         if self.execution_mode == "parallel" and self.parallel_agent_statuses:
             return all(s in ("completed", "failed") for s in self.parallel_agent_statuses.values())


### PR DESCRIPTION
## Summary

Fixes three interconnected bugs that caused parallel agent groups (G2, G3) to execute agents one-at-a-time instead of simultaneously. Observed on issue #3962 where G3 agents (`judge`, `quality-assurance`, `tester`) ran sequentially despite being configured as a parallel group.

Closes #3962

---

## Bug Analysis

### Bug 1: Group state lost during status transitions

**Symptom**: After transitioning from one status to another (e.g., "In Progress" agents complete → "In Review" begins), the parallel group configuration was silently dropped.

**Root Cause**: `_transition_after_pipeline_complete()` calls `remove_pipeline_state()` to clear the old status's pipeline, then calls `assign_agent_for_status()` to start the new status. Inside `assign_agent_for_status`, it reads `existing_pipeline = get_pipeline_state(issue_number)` which returns `None` (just removed), so it creates the new `PipelineState` with `groups=[]`. All subsequent poll cycles see an empty groups list, causing `if pipeline.groups` to short-circuit — the parallel dispatch path is never entered.

**Fix**: Build `PipelineGroupInfo` objects from `config.group_mappings` for the new status BEFORE calling `assign_agent_for_status()`. Pre-create the pipeline state with groups so it survives the assignment call. When the first group is parallel, dispatch ALL agents with a 2-second stagger (matching the existing parallel dispatch pattern in `_advance_pipeline`).

### Bug 2: Only one parallel agent checked per poll cycle

**Symptom**: When parallel agents complete out of order (e.g., agent[2] finishes before agent[0]), those completions go undetected until agent[0] finishes.

**Root Cause**: `_process_pipeline_completion()` only checks `pipeline.current_agent` for completion. In parallel groups, `current_agent` always returns `agents[current_agent_index_in_group]` which stays at index 0 — it never rotates through the other agents. Completions from agents at index 1+ are invisible.

**Fix**: When the current group is parallel, iterate ALL agents with `active` status and check each for completion. Advance the pipeline for every completed agent found in the same poll cycle. Pass the completed agent's name explicitly via the new `completed_agent_name` parameter to `_advance_pipeline` instead of relying on `current_agent`.

### Bug 3: Sequential group `is_complete` always returns `False`

**Symptom**: Sequential groups within a multi-group pipeline would never report completion, blocking the pipeline from advancing to the next group.

**Root Cause**: `PipelineState.is_complete` checks `if group.execution_mode == "parallel"` and returns the correct result for parallel groups, but the `else` branch for sequential groups unconditionally returned `False` — even when `current_agent_index_in_group >= len(group.agents)`.

**Fix**: Return `self.current_agent_index_in_group >= len(group.agents)` for sequential groups instead of hard-coded `False`.

---

## Files Changed

| File | Change |
|------|--------|
| `solune/backend/src/services/copilot_polling/pipeline.py` | `_transition_after_pipeline_complete`: Build groups from config, parallel first-group dispatch |
| | `_process_pipeline_completion`: Parallel group agent sweep (check ALL active agents) |
| | `_advance_pipeline`: New `completed_agent_name` parameter for parallel completions |
| `solune/backend/src/services/workflow_orchestrator/models.py` | `PipelineState.is_complete`: Fix sequential group completion check |

---

## Log Evidence (Issue #3962)

Before fix — agents dispatched sequentially despite parallel group config:
```
19:21:32 - Assigning next agent 'judge' to issue #3962
19:22:51 - Agent 'judge' completed on issue #3962 (5/7 agents done)
19:23:00 - Assigning next agent 'quality-assurance' to issue #3962  ← should have been assigned WITH judge
19:24:06 - Agent 'quality-assurance' completed on issue #3962 (6/7 agents done)
19:24:16 - Assigning next agent 'tester' to issue #3962  ← should have been assigned WITH judge
```

Expected behavior after fix:
```
Assigning parallel group 'G3' (3 agents) to issue #3962
  → judge (assigned)
  → quality-assurance (assigned, +2s stagger)
  → tester (assigned, +4s stagger)
```

---

## Validation

| Check | Result |
|-------|--------|
| Pyright | ✅ 0 errors |
| Ruff (lint + format) | ✅ Clean |
| Pytest | ✅ 1997/1997 tests pass |

---

## How to Test

1. Create a pipeline with multiple execution groups, at least one parallel (e.g., the Expert10 preset which has G2/G3 parallel groups)
2. Launch the pipeline on a new issue
3. Observe that when G1 (series) completes, G2's agents are ALL assigned simultaneously with ~2s stagger
4. When G2 completes, G3's agents are ALL assigned simultaneously
5. Check docker logs: should see "Assigning parallel group" messages instead of sequential "Assigning next agent" messages