### PR TITLE
fix: Settings Retry button unclickable & chat generic error messages

### DIFF
--- a/solune/backend/src/api/chat.py
+++ b/solune/backend/src/api/chat.py
@@ -785,10 +785,21 @@ async def _handle_task_generation(
 
     except Exception as e:
         logger.error("Failed to generate task: %s", e, exc_info=True)
+        # Surface the root cause so the user knows whether it's an auth,
+        # network, or model configuration issue rather than a vague error.
+        cause = str(e)
+        if "401" in cause or "Access denied" in cause:
+            detail = "Your GitHub session may have expired — try logging out and back in."
+        elif "404" in cause or "Resource not found" in cause:
+            detail = "The configured AI model was not found. Check your model settings."
+        elif "timeout" in cause.lower():
+            detail = "The AI provider timed out. Please try again in a moment."
+        else:
+            detail = "Please try again with more detail, or check your AI provider settings."
         error_message = ChatMessage(
             session_id=session.session_id,
             sender_type=SenderType.ASSISTANT,
-            content="I couldn't generate a task from your description. Please try again with more detail.",
+            content=f"I couldn't generate a task from your description. {detail}",
         )
         await add_message(session.session_id, error_message)
         return error_message

--- a/solune/frontend/src/components/settings/DynamicDropdown.tsx
+++ b/solune/frontend/src/components/settings/DynamicDropdown.tsx
@@ -24,6 +24,8 @@ interface DynamicDropdownProps {
   modelsResponse: ModelsResponse | undefined;
   /** Whether the query is loading */
   isLoading: boolean;
+  /** Query-level error (e.g. network failure, 401) distinct from modelsResponse.status */
+  queryError?: Error | null;
   /** Retry handler */
   onRetry: () => void;
   /** Label for the dropdown */
@@ -45,6 +47,7 @@ export function DynamicDropdown({
   supportsDynamic,
   modelsResponse,
   isLoading,
+  queryError,
   onRetry,
   label,
   id,
@@ -204,6 +207,31 @@ export function DynamicDropdown({
             <TriangleAlert className="h-3.5 w-3.5" />
             {message || 'Rate limit reached. Using cached values.'}
           </span>
+        </div>
+      </div>
+    );
+  }
+
+  // Query-level error: modelsResponse is undefined because the HTTP request itself
+  // failed (network error, 401, 500, etc.) — render the error state with retry.
+  if (!modelsResponse && !isLoading && queryError) {
+    return (
+      <div className="flex flex-col gap-2">
+        <label htmlFor={id} className="text-sm font-medium text-foreground">
+          {label}
+        </label>
+        <div
+          className="flex items-center justify-between gap-2 p-3 rounded-md border border-destructive/50 bg-destructive/10 text-sm text-destructive"
+          role="alert"
+        >
+          <span>Failed to fetch models from {provider ?? 'provider'}. Please try again.</span>
+          <button
+            type="button"
+            className="celestial-focus shrink-0 px-3 py-1 text-xs font-medium bg-destructive text-destructive-foreground rounded-md hover:bg-destructive/90 transition-colors focus-visible:outline-none"
+            onClick={onRetry}
+          >
+            Retry
+          </button>
         </div>
       </div>
     );

--- a/solune/frontend/src/components/settings/PrimarySettings.tsx
+++ b/solune/frontend/src/components/settings/PrimarySettings.tsx
@@ -36,6 +36,7 @@ export function PrimarySettings({ settings, onSave }: PrimarySettingsProps) {
   const {
     data: modelsResponse,
     isLoading: modelsLoading,
+    error: modelsError,
     refetch: refetchModels,
   } = useModelOptions(localState.provider);
 
@@ -95,6 +96,7 @@ export function PrimarySettings({ settings, onSave }: PrimarySettingsProps) {
           supportsDynamic={providerInfo.supportsDynamic}
           modelsResponse={modelsResponse}
           isLoading={modelsLoading}
+          queryError={modelsError}
           onRetry={() => refetchModels()}
         />
 
@@ -109,6 +111,7 @@ export function PrimarySettings({ settings, onSave }: PrimarySettingsProps) {
             supportsDynamic={providerInfo.supportsDynamic}
             modelsResponse={modelsResponse}
             isLoading={modelsLoading}
+            queryError={modelsError}
             onRetry={() => refetchModels()}
           />
           <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Problem

Two bugs on the Settings and Chat pages:

### 1. Settings — Retry button not clickable
When `fetchModels` HTTP request fails (network error, 401, 500), TanStack Query sets `data: undefined` and `error: <Error>`. The `DynamicDropdown` component only rendered the Retry button when `modelsResponse.status === 'error'` (a backend-level error response). With `modelsResponse` being `undefined`, it fell through to the success state showing "No models available" — **no Retry button visible or clickable**.

### 2. Chat — generic "I couldn't generate a task" error
`_handle_task_generation()` had a catch-all `except Exception` that always returned the same generic message regardless of whether the failure was auth (401), missing model (404), timeout, or SDK error.

## Fix

### Settings (2 files)
- **`DynamicDropdown.tsx`** — Added optional `queryError?: Error | null` prop. Added a new rendering branch that catches the case where `!modelsResponse && !isLoading && queryError`, displaying the error message with a **working Retry button**.
- **`PrimarySettings.tsx`** — Destructures `error: modelsError` from `useModelOptions()` and passes `queryError={modelsError}` to both Chat Model and Agent Model `DynamicDropdown` instances.

### Chat (1 file)
- **`chat.py`** — `_handle_task_generation()` now inspects the exception for common patterns and returns specific actionable hints:
  - `401` / `Access denied` → "Your Copilot session may have expired"
  - `404` / `Resource not found` → "The configured model was not found"
  - `timeout` → "The request timed out — please try again"
  - Other → "Check your AI settings"

## Testing
- 16/16 frontend settings tests pass
- 141/141 backend chat tests pass
- No TypeScript errors