### PR TITLE
fix: wire drag-and-drop status persistence into Kanban board

### DIFF
--- a/solune/backend/src/api/board.py
+++ b/solune/backend/src/api/board.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Body, Depends, Query
 from githubkit.exception import PrimaryRateLimitExceeded, RequestFailed
 
 from src.api.auth import get_session_dep
@@ -431,3 +431,47 @@ async def get_board_data(
     board_hash = compute_data_hash(board_data.model_dump(mode="json", exclude={"rate_limit"}))
     cache.set(cache_key, board_data, ttl_seconds=300, data_hash=board_hash)
     return board_data
+
+
+@router.patch("/projects/{project_id}/items/{item_id}/status")
+async def update_item_status(
+    project_id: str,
+    item_id: str,
+    session: Annotated[UserSession, Depends(get_session_dep)],
+    status: Annotated[str, Body(embed=True, description="Target status name")],
+) -> dict[str, bool]:
+    """Move a board item to a different status column."""
+    try:
+        success = await github_projects_service.update_item_status_by_name(
+            access_token=session.access_token,
+            project_id=project_id,
+            item_id=item_id,
+            status_name=status,
+        )
+    except Exception as e:
+        if _is_github_auth_error(e):
+            raise AuthenticationError(
+                "Your GitHub session has expired. Please log in again."
+            ) from e
+        if _is_github_rate_limit_error(e):
+            raise RateLimitError(
+                message="GitHub API rate limit exceeded",
+                retry_after=_retry_after_seconds(e),
+                details=_rate_limit_details(),
+            ) from e
+        logger.error("Failed to update item status: %s", e, exc_info=True)
+        raise GitHubAPIError(
+            message="Failed to update item status",
+            details={"reason": _classify_github_error(e)},
+        ) from e
+
+    if not success:
+        raise GitHubAPIError(
+            message="Could not update item status — the status option may not exist."
+        )
+
+    # Invalidate cached board data so the next fetch reflects the change.
+    cache_key = get_cache_key(CACHE_PREFIX_BOARD_DATA, project_id)
+    cache.delete(cache_key)
+
+    return {"success": True}

--- a/solune/frontend/src/components/board/ProjectBoardContent.tsx
+++ b/solune/frontend/src/components/board/ProjectBoardContent.tsx
@@ -20,6 +20,7 @@ interface ProjectBoardContentProps {
   boardControls: BoardControls;
   onCardClick: (item: BoardItem) => void;
   availableAgents: AvailableAgent[];
+  onStatusUpdate?: (itemId: string, newStatus: string) => Promise<void>;
 }
 
 export function ProjectBoardContent({
@@ -27,6 +28,7 @@ export function ProjectBoardContent({
   boardControls,
   onCardClick,
   availableAgents,
+  onStatusUpdate,
 }: ProjectBoardContentProps) {
   const allEmpty = boardData.columns.every((col) => col.items.length === 0);
 
@@ -72,6 +74,7 @@ export function ProjectBoardContent({
         onCardClick={onCardClick}
         availableAgents={availableAgents}
         getGroups={boardControls.getGroups}
+        onStatusUpdate={onStatusUpdate}
       />
     </div>
   );

--- a/solune/frontend/src/pages/ProjectsPage.tsx
+++ b/solune/frontend/src/pages/ProjectsPage.tsx
@@ -26,7 +26,7 @@ import { formatTimeAgo } from '@/utils/formatTime';
 import { extractRateLimitInfo, isRateLimitApiError } from '@/utils/rateLimit';
 import { cn } from '@/lib/utils';
 import type { BoardItem } from '@/types';
-import { pipelinesApi } from '@/services/api';
+import { boardApi, pipelinesApi } from '@/services/api';
 import { CelestialCatalogHero } from '@/components/common/CelestialCatalogHero';
 import { Button } from '@/components/ui/button';
 
@@ -107,6 +107,23 @@ export function ProjectsPage() {
 
   const handleCardClick = useCallback((item: BoardItem) => setSelectedItem(item), []);
   const handleCloseModal = useCallback(() => setSelectedItem(null), []);
+
+  const statusUpdateMutation = useMutation({
+    mutationFn: ({ itemId, status }: { itemId: string; status: string }) =>
+      boardApi.updateItemStatus(selectedProjectId!, itemId, status),
+    onSuccess: () => {
+      if (selectedProjectId) {
+        void queryClient.invalidateQueries({ queryKey: ['boardData', selectedProjectId] });
+      }
+    },
+  });
+
+  const handleStatusUpdate = useCallback(
+    async (itemId: string, newStatus: string) => {
+      await statusUpdateMutation.mutateAsync({ itemId, status: newStatus });
+    },
+    [statusUpdateMutation],
+  );
 
   const assignedPipelineName = useMemo(
     () =>
@@ -315,6 +332,7 @@ export function ProjectsPage() {
             boardControls={boardControls}
             onCardClick={handleCardClick}
             availableAgents={availableAgents}
+            onStatusUpdate={handleStatusUpdate}
           />
         </div>
       )}

--- a/solune/frontend/src/services/api.ts
+++ b/solune/frontend/src/services/api.ts
@@ -399,6 +399,16 @@ export const boardApi = {
     const data = await request<BoardDataResponse>(`/board/projects/${projectId}${params}`);
     return validateResponse(BoardDataResponseSchema, data, 'boardApi.getBoardData');
   },
+
+  /**
+   * Move a board item to a different status column.
+   */
+  updateItemStatus(projectId: string, itemId: string, status: string): Promise<{ success: boolean }> {
+    return request<{ success: boolean }>(`/board/projects/${projectId}/items/${itemId}/status`, {
+      method: 'PATCH',
+      body: JSON.stringify({ status }),
+    });
+  },
 };
 
 // ============ Settings API ============


### PR DESCRIPTION
## Problem

Drag-and-drop on the Kanban board was **visually functional** but **did not persist** status changes. All `@dnd-kit` components (`DndContext`, `useDroppable`, `useDraggable`, `DragOverlay`) were properly wired in the board UI, but the mutation callback to save to GitHub was never connected — `onStatusUpdate` was accepted by `ProjectBoard` but never passed from the page.

## Root Cause

- `ProjectBoardContent` did not accept or forward the `onStatusUpdate` prop
- `ProjectsPage` did not create a mutation to call a backend endpoint
- No backend endpoint existed to update an item's status column

## Fix

### Backend (1 file)
**`board.py`** — Added `PATCH /board/projects/{project_id}/items/{item_id}/status` endpoint:
- Accepts `{ "status": "In Progress" }` body
- Delegates to `github_projects_service.update_item_status_by_name()`
- Handles auth errors (401 → `AuthenticationError`), rate limits, and API failures
- Invalidates the board data cache after successful update

### Frontend (3 files)
**`api.ts`** — Added `boardApi.updateItemStatus(projectId, itemId, status)` method

**`ProjectBoardContent.tsx`** — Added optional `onStatusUpdate` prop, forwarded to `ProjectBoard`

**`ProjectsPage.tsx`** — Created a `useMutation` that calls `boardApi.updateItemStatus` and invalidates the `boardData` query on success. Passes `handleStatusUpdate` through `ProjectBoardContent`

## End-to-End Flow

```
User drags card → DndContext.onDragEnd
  → useBoardDragDrop extracts target column
  → onStatusUpdate(itemId, targetStatus)
  → statusUpdateMutation.mutateAsync
  → PATCH /board/projects/{id}/items/{itemId}/status
  → github_projects_service.update_item_status_by_name (GitHub GraphQL)
  → cache invalidation → query refetch → board updates
```

## Testing
- 75/75 backend board tests pass
- 1178/1178 frontend tests pass (134 test files)
- No TypeScript errors