### PR TITLE
fix(nginx): prevent stale index.html from serving outdated JS bundles

### DIFF
--- a/solune/frontend/nginx.conf
+++ b/solune/frontend/nginx.conf
@@ -39,7 +39,13 @@ server {
     }
 
     # SPA fallback - serve index.html for all routes
+    # index.html must never be aggressively cached since it references
+    # content-hashed JS/CSS bundles.  A stale HTML file would point the
+    # browser at an outdated bundle, causing features to appear missing.
     location / {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires 0;
         try_files $uri $uri/ /index.html;
     }
 


### PR DESCRIPTION
## Problem

After PR #5689 (section header toggles & main branch protection) was merged and the frontend Docker image rebuilt, **clicking the section headers in the Cleanup modal did nothing** — the shield icons were visible but non-responsive.

### Root Cause

The Nginx `location /` block served `index.html` **without any cache-control headers**. Meanwhile, content-hashed static assets under `/assets/` were served with aggressive caching:

```
Cache-Control: public, immutable
Expires: 1 year
```

This is correct for hashed assets — but `index.html` is the SPA entry point that **references those assets by their content-hash filename**. When the Docker image was rebuilt with new code:

1. Vite produced a new JS bundle with a new hash (e.g. `ChoresPage-DhYgVAV9.js`)
2. The new `index.html` referenced this new bundle
3. **But browsers that cached the old `index.html` kept requesting the old bundle**

In this specific case, the old bundle rendered section headers as static `<span>` elements (the pre-#5689 code), while the new bundle renders them as interactive `<button>` elements with `onClick` handlers. The headers **looked** clickable (icons were present) but the underlying code was the old non-interactive version.

### Investigation Steps

1. Verified the source code in the repo was correct — `<button>` elements with proper `onClick` handlers ✅
2. Verified unit tests pass (12/12) ✅
3. Verified the Docker container's built JS contained the toggle functions ✅
4. Checked CSS for `pointer-events: none` or other interference — none found ✅
5. Inspected Nginx cache headers on `index.html` — **no cache-control headers** ❌
6. Confirmed the old code used `<span>` wrappers, confirming the browser was loading stale code

## Fix

Add explicit no-cache headers to the SPA root `location /` block:

```nginx
location / {
    add_header Cache-Control "no-cache, no-store, must-revalidate";
    add_header Pragma "no-cache";
    add_header Expires 0;
    try_files $uri $uri/ /index.html;
}
```

### What this does

| Resource | Before | After |
|----------|--------|-------|
| `index.html` (~1KB) | No cache headers (browser default caching) | `no-cache, no-store, must-revalidate` — always re-validated |
| `/assets/*.js` (hashed) | `public, immutable`, 1yr | **Unchanged** — still aggressively cached |
| `/assets/*.css` (hashed) | `public, immutable`, 1yr | **Unchanged** — still aggressively cached |

This is the standard SPA caching strategy: the tiny HTML entry point is always fresh, while the large hashed assets are cached indefinitely. The browser makes one small conditional request for `index.html` per navigation, then loads everything else from cache.

## Verification

After rebuilding and restarting the container:

```
$ curl -sI http://localhost:5173/ | grep -i cache
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Expires: 0

$ curl -sI http://localhost:5173/assets/ChoresPage-DhYgVAV9.js | grep -i cache
Cache-Control: max-age=31536000
Cache-Control: public, immutable
```

## Files Changed

- `solune/frontend/nginx.conf` — Add cache-busting headers to SPA root location block + explanatory comment