### PR TITLE
fix: correct Copilot SDK import and align Add Agent button styling

### DIFF
--- a/solune/backend/src/services/completion_providers.py
+++ b/solune/backend/src/services/completion_providers.py
@@ -59,13 +59,11 @@ class CopilotClientPool:
             if key in self._clients:
                 return self._clients[key]
 
-            from copilot import (  # type: ignore[reportMissingImports]
-                CopilotClient,
-                SubprocessConfig,  # pyright: ignore[reportAttributeAccessIssue]
-            )
+            from copilot import CopilotClient  # type: ignore[reportMissingImports]
+            from copilot.types import CopilotClientOptions
 
-            config = SubprocessConfig(github_token=github_token)
-            client = CopilotClient(config=config, auto_start=False)  # pyright: ignore[reportCallIssue]
+            options = CopilotClientOptions(github_token=github_token, auto_start=False)
+            client = CopilotClient(options=options)
             await client.start()
             self._clients[key] = client
             logger.info(

--- a/solune/frontend/src/components/agents/AgentsPanel.tsx
+++ b/solune/frontend/src/components/agents/AgentsPanel.tsx
@@ -249,7 +249,6 @@ export function AgentsPanel({
           <Button
             onClick={handleOpenAddModal}
             size="lg"
-            className="!bg-primary !text-primary-foreground !border-primary/60 hover:!bg-primary/90"
           >
             + Add Agent
           </Button>


### PR DESCRIPTION
## Summary

Two targeted fixes: a backend bug preventing AI model loading on the Settings page, and a frontend styling inconsistency on the Agents page.

---

## Backend: Fix broken Copilot SDK client construction

### Problem
The Settings page showed **"Failed to fetch models from copilot. Please try again."** for both the Chat Model and Agent Model (Auto) dropdowns. All AI completion operations (agent runs, chat completions) were also broken.

### Root Cause
`CopilotClientPool.get_or_create()` in `completion_providers.py` imported `SubprocessConfig` from the `copilot` SDK, which **does not exist** in the installed version (v0.1.0+). This raised an `ImportError` on every call, silently caught by the generic `except Exception` handler in `model_fetcher.py`.

### Fix
Replace the non-existent `SubprocessConfig` import with the correct SDK API:
- `from copilot import CopilotClient` (unchanged)
- `from copilot.types import CopilotClientOptions` (correct import path)
- Construct via `CopilotClientOptions(github_token=..., auto_start=False)` instead of `SubprocessConfig(github_token=...)`
- Pass `options=` to `CopilotClient()` instead of `config=`

### Impact
- Settings page model dropdowns now load correctly
- All AI operations through `CopilotClientPool` (agent completions, chat) are restored

### Verification
- Confirmed `CopilotClientOptions` exists in the installed SDK with the expected fields (`github_token`, `auto_start`, etc.)
- Confirmed `CopilotClient(options=CopilotClientOptions(...))` constructs successfully at runtime
- All 623 related unit tests pass

---

## Frontend: Remove important-overrides from Add Agent button

### Problem
The "+ Add Agent" button on the Agents page had a visible border and slightly different styling compared to other primary buttons in the app.

### Root Cause
The button had CSS `!important` overrides (`!bg-primary !text-primary-foreground !border-primary/60 hover:!bg-primary/90`) that fought against the shared `<Button>` component's `default` variant. The `default` variant already provides the correct celestial theme styling (solar-action class, shadows, hover lift, rounded-full pill shape). The `!border-primary/60` override specifically added a visible border not present on any other primary button.

### Fix
Remove the `className` overrides so the button inherits the standard `default` variant styling from the shared Button component.

### Impact
The "+ Add Agent" button now matches "Refresh models" and all other primary action buttons across the app.

---

## Files Changed

| File | Change |
|---|---|
| `solune/backend/src/services/completion_providers.py` | Fix `SubprocessConfig` → `CopilotClientOptions` import and constructor |
| `solune/frontend/src/components/agents/AgentsPanel.tsx` | Remove `!important` class overrides from Add Agent button |