### PR TITLE
fix: reduce GitHub API requests to prevent rate limit exhaustion

### DIFF
--- a/backend/src/services/copilot_polling.py
+++ b/backend/src/services/copilot_polling.py
@@ -46,6 +46,7 @@ async def check_in_progress_issues(
     project_id: str,
     owner: str,
     repo: str,
+    cached_tasks: list | None = None,
 ) -> list[dict[str, Any]]:
     """
     Check all issues in "In Progress" status for completed Copilot PRs.
@@ -55,6 +56,7 @@ async def check_in_progress_issues(
         project_id: GitHub Project V2 node ID
         owner: Repository owner (fallback if not in task)
         repo: Repository name (fallback if not in task)
+        cached_tasks: Pre-fetched project items to avoid duplicate API call
 
     Returns:
         List of results for each processed issue
@@ -62,8 +64,10 @@ async def check_in_progress_issues(
     results = []
 
     try:
-        # Get all project items
-        tasks = await github_projects_service.get_project_items(access_token, project_id)
+        # Use cached tasks if provided, otherwise fetch
+        tasks = cached_tasks if cached_tasks is not None else (
+            await github_projects_service.get_project_items(access_token, project_id)
+        )
 
         # Filter to "In Progress" items with issue numbers
         in_progress_tasks = [
@@ -117,6 +121,7 @@ async def check_in_review_issues_for_copilot_review(
     project_id: str,
     owner: str,
     repo: str,
+    cached_tasks: list | None = None,
 ) -> list[dict[str, Any]]:
     """
     Check all issues in "In Review" status to ensure Copilot has reviewed their PRs.
@@ -128,6 +133,7 @@ async def check_in_review_issues_for_copilot_review(
         project_id: GitHub Project V2 node ID
         owner: Repository owner
         repo: Repository name
+        cached_tasks: Pre-fetched project items to avoid duplicate API call
 
     Returns:
         List of results for each processed issue
@@ -135,8 +141,10 @@ async def check_in_review_issues_for_copilot_review(
     results = []
 
     try:
-        # Get all project items
-        tasks = await github_projects_service.get_project_items(access_token, project_id)
+        # Use cached tasks if provided, otherwise fetch
+        tasks = cached_tasks if cached_tasks is not None else (
+            await github_projects_service.get_project_items(access_token, project_id)
+        )
 
         # Filter to "In Review" items with issue numbers
         in_review_tasks = [
@@ -492,12 +500,16 @@ async def poll_for_copilot_completion(
 
             logger.debug("Polling for Copilot PR completions (poll #%d)", _polling_state.poll_count)
 
+            # Fetch project items once per cycle to avoid duplicate API calls
+            all_tasks = await github_projects_service.get_project_items(access_token, project_id)
+
             # Step 1: Check "In Progress" issues for completed Copilot PRs
             results = await check_in_progress_issues(
                 access_token=access_token,
                 project_id=project_id,
                 owner=owner,
                 repo=repo,
+                cached_tasks=all_tasks,
             )
 
             if results:
@@ -513,6 +525,7 @@ async def poll_for_copilot_completion(
                 project_id=project_id,
                 owner=owner,
                 repo=repo,
+                cached_tasks=all_tasks,
             )
 
             if review_results:

--- a/backend/src/services/github_projects.py
+++ b/backend/src/services/github_projects.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import httpx
 
@@ -534,8 +534,15 @@ mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $text: String!) {
 class GitHubProjectsService:
     """Service for interacting with GitHub Projects V2 API."""
 
+    # TTL for cached project field metadata (seconds).
+    _FIELD_CACHE_TTL = 300  # 5 minutes
+
     def __init__(self):
         self._client = httpx.AsyncClient(timeout=30.0)
+        # Cache for project fields: {project_id: (fields_dict, expiry_datetime)}
+        self._fields_cache: dict[str, tuple[dict[str, dict], datetime]] = {}
+        # Cache for single Status field lookups: {project_id: (field_data, expiry_datetime)}
+        self._status_field_cache: dict[str, tuple[dict, datetime]] = {}
 
     async def close(self):
         """Close HTTP client."""
@@ -1450,6 +1457,9 @@ class GitHubProjectsService:
         """
         Update an item's status by status name (helper method).
 
+        Uses a 5-minute in-memory cache for the Status field metadata to avoid
+        redundant GraphQL lookups on every status transition.
+
         Args:
             access_token: GitHub OAuth access token
             project_id: GitHub Project V2 node ID
@@ -1459,14 +1469,31 @@ class GitHubProjectsService:
         Returns:
             True if update succeeded
         """
-        # Get project field info
-        data = await self._graphql(
-            access_token,
-            GET_PROJECT_FIELD_QUERY,
-            {"projectId": project_id},
-        )
+        # Check in-memory cache for Status field data
+        cached = self._status_field_cache.get(project_id)
+        if cached:
+            field_data, expires_at = cached
+            if datetime.utcnow() < expires_at:
+                logger.debug("Status field cache hit for project %s", project_id)
+            else:
+                field_data = None
+        else:
+            field_data = None
 
-        field_data = data.get("node", {}).get("field", {})
+        if field_data is None:
+            # Fetch from API and cache
+            data = await self._graphql(
+                access_token,
+                GET_PROJECT_FIELD_QUERY,
+                {"projectId": project_id},
+            )
+            field_data = data.get("node", {}).get("field", {})
+            if field_data.get("id"):
+                self._status_field_cache[project_id] = (
+                    field_data,
+                    datetime.utcnow() + timedelta(seconds=self._FIELD_CACHE_TTL),
+                )
+
         field_id = field_data.get("id")
         options = field_data.get("options", [])
 
@@ -1508,7 +1535,7 @@ class GitHubProjectsService:
         project_id: str,
     ) -> dict[str, dict]:
         """
-        Get all fields from a project.
+        Get all fields from a project (cached for 5 minutes).
 
         Args:
             access_token: GitHub OAuth access token
@@ -1517,6 +1544,14 @@ class GitHubProjectsService:
         Returns:
             Dict mapping field names to field info (id, dataType, options if applicable)
         """
+        # Check in-memory cache first
+        cached = self._fields_cache.get(project_id)
+        if cached:
+            fields_data, expires_at = cached
+            if datetime.utcnow() < expires_at:
+                logger.debug("Project fields cache hit for %s", project_id)
+                return fields_data
+
         try:
             data = await self._graphql(
                 access_token,
@@ -1539,6 +1574,11 @@ class GitHubProjectsService:
                     }
 
             logger.debug("Found %d project fields: %s", len(fields), list(fields.keys()))
+            # Store in cache
+            self._fields_cache[project_id] = (
+                fields,
+                datetime.utcnow() + timedelta(seconds=self._FIELD_CACHE_TTL),
+            )
             return fields
 
         except Exception as e:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -124,7 +124,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -474,7 +473,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -515,7 +513,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1692,7 +1689,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1777,7 +1775,6 @@
       "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1795,7 +1792,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1807,7 +1803,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1857,7 +1852,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2193,7 +2187,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2244,6 +2237,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2277,6 +2271,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2349,7 +2344,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2579,6 +2573,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2588,7 +2583,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.283",
@@ -2707,7 +2703,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3180,7 +3175,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -3337,6 +3331,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3537,7 +3532,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3653,6 +3647,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3668,6 +3663,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3690,7 +3686,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3703,7 +3698,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3717,7 +3711,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4063,7 +4058,6 @@
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4150,7 +4144,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -4749,7 +4742,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -7,6 +7,14 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { chatApi, tasksApi } from '@/services/api';
 import type { AITaskProposal, ChatMessage, ProposalConfirmRequest, IssueCreateActionData } from '@/types';
 
+/** Invalidate only the tasks for the currently selected project, not the entire projects list. */
+function invalidateProjectTasks(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: ['projects'], exact: false, predicate: (query) => {
+    // Only invalidate task-level queries, not the top-level project list
+    return query.queryKey.length >= 3 && query.queryKey[2] === 'tasks';
+  }});
+}
+
 // Extended proposal type for status changes
 interface StatusChangeProposal {
   proposal_id: string;
@@ -49,7 +57,7 @@ export function useChat(): UseChatReturn {
   } = useQuery({
     queryKey: ['chat', 'messages'],
     queryFn: chatApi.getMessages,
-    staleTime: 10 * 1000, // 10 seconds
+    staleTime: 60 * 1000, // 60 seconds
   });
 
   // Send message mutation
@@ -124,8 +132,8 @@ export function useChat(): UseChatReturn {
         return next;
       });
       queryClient.invalidateQueries({ queryKey: ['chat', 'messages'] });
-      // Also refresh tasks
-      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      // Refresh only task-level queries, not the full project list
+      invalidateProjectTasks(queryClient);
     },
   });
 
@@ -147,8 +155,8 @@ export function useChat(): UseChatReturn {
         return next;
       });
       queryClient.invalidateQueries({ queryKey: ['chat', 'messages'] });
-      // Refresh tasks to show updated status
-      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      // Refresh only task-level queries, not the full project list
+      invalidateProjectTasks(queryClient);
     },
   });
 

--- a/frontend/src/hooks/useRealTimeSync.ts
+++ b/frontend/src/hooks/useRealTimeSync.ts
@@ -1,5 +1,10 @@
 /**
  * Real-time sync hook for WebSocket updates with polling fallback.
+ *
+ * Optimized to reduce GitHub API requests:
+ * - Polling is stopped when WebSocket is connected (no dual-sync)
+ * - Polling fallback interval increased from 5s to 30s
+ * - WebSocket message invalidations are debounced (2s window)
  */
 
 import { useEffect, useRef, useCallback, useState } from 'react';
@@ -12,6 +17,12 @@ interface UseRealTimeSyncReturn {
   lastUpdate: Date | null;
 }
 
+/** Polling fallback interval in ms (only used when WebSocket is unavailable). */
+const POLLING_INTERVAL_MS = 30_000;
+
+/** Debounce window for WebSocket-triggered cache invalidations. */
+const INVALIDATION_DEBOUNCE_MS = 2_000;
+
 export function useRealTimeSync(projectId: string | null): UseRealTimeSyncReturn {
   const queryClient = useQueryClient();
   const [status, setStatus] = useState<SyncStatus>('disconnected');
@@ -21,6 +32,19 @@ export function useRealTimeSync(projectId: string | null): UseRealTimeSyncReturn
   const reconnectTimeoutRef = useRef<number | null>(null);
   const reconnectAttempts = useRef(0);
   const maxReconnectAttempts = 3;
+  const debounceTimerRef = useRef<number | null>(null);
+
+  /** Debounced query invalidation — collapses rapid WebSocket messages. */
+  const debouncedInvalidate = useCallback(() => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+    debounceTimerRef.current = window.setTimeout(() => {
+      queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'tasks'] });
+      setLastUpdate(new Date());
+      debounceTimerRef.current = null;
+    }, INVALIDATION_DEBOUNCE_MS);
+  }, [projectId, queryClient]);
 
   const handleMessage = useCallback(
     (event: MessageEvent) => {
@@ -29,23 +53,19 @@ export function useRealTimeSync(projectId: string | null): UseRealTimeSyncReturn
 
         // Handle initial data with all tasks
         if (data.type === 'initial_data' || data.type === 'refresh') {
-          // Force refresh to get the updated data
-          queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'tasks'] });
-          setLastUpdate(new Date());
+          debouncedInvalidate();
           return;
         }
 
         // Handle real-time updates
         if (data.type === 'task_update' || data.type === 'task_created' || data.type === 'status_changed') {
-          // Invalidate tasks query to refetch
-          queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'tasks'] });
-          setLastUpdate(new Date());
+          debouncedInvalidate();
         }
       } catch (e) {
         console.error('Failed to parse WebSocket message:', e);
       }
     },
-    [projectId, queryClient]
+    [debouncedInvalidate]
   );
 
   const startPolling = useCallback(() => {
@@ -57,7 +77,7 @@ export function useRealTimeSync(projectId: string | null): UseRealTimeSyncReturn
     pollingIntervalRef.current = window.setInterval(() => {
       queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'tasks'] });
       setLastUpdate(new Date());
-    }, 5000); // Poll every 5 seconds
+    }, POLLING_INTERVAL_MS);
   }, [projectId, queryClient]);
 
   const stopPolling = useCallback(() => {
@@ -99,7 +119,8 @@ export function useRealTimeSync(projectId: string | null): UseRealTimeSyncReturn
         clearTimeout(connectionTimeout);
         setStatus('connected');
         setLastUpdate(new Date());
-        // Keep polling as backup even with WebSocket
+        // Stop polling — WebSocket provides real-time updates
+        stopPolling();
         reconnectAttempts.current = 0;
       };
 
@@ -115,6 +136,9 @@ export function useRealTimeSync(projectId: string | null): UseRealTimeSyncReturn
         clearTimeout(connectionTimeout);
         wsRef.current = null;
 
+        // Resume polling as fallback while attempting reconnect
+        startPolling();
+
         // Only attempt reconnect a few times before giving up
         if (reconnectAttempts.current < maxReconnectAttempts) {
           reconnectAttempts.current++;
@@ -123,9 +147,6 @@ export function useRealTimeSync(projectId: string | null): UseRealTimeSyncReturn
               connect();
             }
           }, 5000);
-        } else {
-          // After max attempts, stay in polling mode
-          startPolling();
         }
       };
 
@@ -134,7 +155,7 @@ export function useRealTimeSync(projectId: string | null): UseRealTimeSyncReturn
       // WebSocket not supported or blocked, use polling
       startPolling();
     }
-  }, [projectId, handleMessage, startPolling]);
+  }, [projectId, handleMessage, startPolling, stopPolling]);
 
   // Connect when project changes
   useEffect(() => {
@@ -157,6 +178,9 @@ export function useRealTimeSync(projectId: string | null): UseRealTimeSyncReturn
       stopPolling();
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
+      }
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
       }
     };
   }, [projectId, connect, startPolling, stopPolling]);


### PR DESCRIPTION
## Problem

The application is hitting GitHub API rate limits due to excessive and redundant API calls across the frontend and backend. Key issues identified:

- **Frontend dual-sync**: The 5-second polling interval ran **continuously alongside** an active WebSocket connection, doubling API traffic
- **Uncached field metadata**: Every status transition triggered a fresh GraphQL query to fetch project field IDs and option IDs (~35 call sites)
- **Duplicate project item fetches**: The polling loop fetched all project items **twice per cycle** — once for "In Progress" checks and again for "In Review" checks
- **Aggressive cache invalidation**: Every chat action (send message, confirm proposal, status change) invalidated the **entire** `['projects']` query, triggering full project list refetches
- **Short stale times**: Chat messages had a 10-second stale time, causing continuous refetches

## Changes

### Phase 1: Frontend — Real-Time Sync & Cache Optimization

#### `frontend/src/hooks/useRealTimeSync.ts`
- **Stop polling when WebSocket connects**: `ws.onopen` now calls `stopPolling()`. Previously both mechanisms ran simultaneously, causing ~720 redundant API calls/hour per connected client
- **Increase polling fallback interval** from 5s → 30s: Task status changes don't need sub-10-second resolution. Only used when WebSocket is unavailable
- **Add 2-second debounce on WebSocket cache invalidations**: Rapid successive WebSocket messages (e.g., multiple task updates) each triggered `queryClient.invalidateQueries()`. A debounce window collapses these into a single refetch
- **Resume polling on WebSocket close**: Ensures fallback is always active during reconnection attempts
- Extract `POLLING_INTERVAL_MS` and `INVALIDATION_DEBOUNCE_MS` as named constants

#### `frontend/src/hooks/useChat.ts`
- **Scope cache invalidations to task-level queries**: Replace blanket `invalidateQueries({ queryKey: ['projects'] })` with a predicate filter that only invalidates `['projects', *, 'tasks']` queries. Prevents unnecessary full project list refetches on every chat action
- **Increase chat messages staleTime** from 10s → 60s: Chat messages are not modified externally; the aggressive stale time was causing continuous refetching on component re-renders
- Add `invalidateProjectTasks()` helper for consistent scoped invalidation

### Phase 2: Backend — Project Field Metadata Caching

#### `backend/src/services/github_projects.py`
- **Cache `get_project_fields()` results** with 5-minute TTL: This method fetches all project field metadata (Priority, Size, Estimate, dates) via `GET_PROJECT_FIELDS_QUERY`. Previously called once per field inside `set_issue_metadata()` (5× for full metadata) and once per `update_project_item_field()` invocation. Now uses an in-memory dict keyed by `project_id` with expiry timestamp
- **Cache Status field lookup in `update_item_status_by_name()`**: Called on every status transition across the orchestrator and polling loop. Previously made a dedicated `GET_PROJECT_FIELD_QUERY` GraphQL call on every invocation to resolve Status field ID and option IDs. Now caches per `project_id` with 5-minute TTL
- Add `_fields_cache` and `_status_field_cache` instance dicts on `GitHubProjectsService`
- Add `_FIELD_CACHE_TTL` class constant (300 seconds)

### Phase 3: Backend — Polling Cycle Deduplication

#### `backend/src/services/copilot_polling.py`
- **Fetch project items once per polling cycle**: The polling loop called `get_project_items()` independently in both `check_in_progress_issues()` and `check_in_review_issues_for_copilot_review()`, making two identical paginated GraphQL queries per 60-second cycle. Now fetches once at the top of the loop and passes via `cached_tasks` parameter
- **Backward-compatible**: Both functions accept an optional `cached_tasks` parameter and fall back to fetching if not provided, so direct callers (manual API triggers, `check_issue_for_copilot_completion()`) continue to work unchanged

## Estimated Impact

| Optimization | Calls Saved/Hour | Scope |
|---|---|---|
| Stop dual polling+WebSocket sync | ~720+ | Per connected client |
| Field metadata caching (5-min TTL) | ~100-200 | Per active project |
| Polling cycle deduplication | ~60 | Per polling instance |
| Scoped cache invalidations | Variable | Per chat interaction |
| Chat staleTime increase | Variable | Per active chat session |

## Testing

- **Backend**: All 224 unit tests pass (`pytest tests/ -x -q`)
- **Frontend**: All 20 unit tests pass (`vitest run`)
- **Pre-commit**: Ruff formatting, linting, and Pyright type checks pass
- No changes to public API contracts or component interfaces

## Files Changed

| File | Lines | Description |
|------|:---:|-------------|
| `frontend/src/hooks/useRealTimeSync.ts` | +50/-8 | Stop dual-sync, 30s polling, 2s debounce |
| `frontend/src/hooks/useChat.ts` | +18/-3 | Scoped invalidations, 60s staleTime |
| `backend/src/services/github_projects.py` | +58/-5 | Field metadata caching (5-min TTL) |
| `backend/src/services/copilot_polling.py` | +21/-3 | Single fetch per polling cycle |
| `frontend/package-lock.json` | lockfile | npm dependency resolution |